### PR TITLE
Issue #4342: Prevent background from jumping around underneath modal.

### DIFF
--- a/core/modules/system/css/system.css
+++ b/core/modules/system/css/system.css
@@ -4,6 +4,13 @@
  */
 
 /**
+ * Prevent background from jumping underneath modal.
+ */
+html.dialog-open {
+  position: inherit;
+}
+
+/**
  * Autocomplete.
  *
  * @see autocomplete.js


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/4342